### PR TITLE
Apply MainApp.kt to hold the instance of AppInfoRepo

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     android:label="@string/app_name"
     android:roundIcon="@mipmap/ic_launcher_round"
     android:supportsRtl="true"
+    android:name=".MainApp"
     android:theme="@style/Theme.AppStartInfoDemo">
     <activity
       android:name=".MainActivity"

--- a/app/src/main/java/com/demo/core/app_start_up_info/ProdAppInfoRepo.kt
+++ b/app/src/main/java/com/demo/core/app_start_up_info/ProdAppInfoRepo.kt
@@ -16,6 +16,7 @@ class ProdAppInfoRepo(context: Context) : AppInfoRepo {
 
   init {
     activityManager(context).addApplicationStartInfoCompletionListener(Executors.newSingleThreadExecutor()) {
+      println("received app_startup ApplicationStartInfo: $it")
       behaviorSubject.onNext(AppStartInfoMapper.mapStartInfo(it))
     }
   }

--- a/app/src/main/java/com/tomas/repcik/appstartinfodemo/DeviceBootReceiver.kt
+++ b/app/src/main/java/com/tomas/repcik/appstartinfodemo/DeviceBootReceiver.kt
@@ -8,7 +8,7 @@ class DeviceBootReceiver : BroadcastReceiver() {
 
   override fun onReceive(context: Context, intent: Intent) {
     if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
-      println("Device boot completed. Starting app...")
+      println("app_startup Device boot completed. Starting app.")
     }
   }
 }

--- a/app/src/main/java/com/tomas/repcik/appstartinfodemo/MainActivity.kt
+++ b/app/src/main/java/com/tomas/repcik/appstartinfodemo/MainActivity.kt
@@ -19,7 +19,7 @@ class MainActivity : ComponentActivity() {
   }
 
   private fun loadStartUpModel() {
-    AppInfoRepo.create(application).streaming().observeOn(AndroidSchedulers.mainThread())
+    (application as MainApp).repo().streaming().observeOn(AndroidSchedulers.mainThread())
       .autoDispose(from(this))
       .subscribe(::renderModel)
   }

--- a/app/src/main/java/com/tomas/repcik/appstartinfodemo/MainApp.kt
+++ b/app/src/main/java/com/tomas/repcik/appstartinfodemo/MainApp.kt
@@ -1,0 +1,19 @@
+package com.tomas.repcik.appstartinfodemo
+
+import android.app.Application
+import com.demo.core.app_start_up_info.model.AppInfoRepo
+
+class MainApp : Application() {
+
+  private lateinit var repo :AppInfoRepo
+
+  override fun onCreate() {
+    super.onCreate()
+    repo =AppInfoRepo.create(this)
+  }
+
+  fun repo() : AppInfoRepo {
+    return repo
+  }
+
+}


### PR DESCRIPTION
```
08:03:46.587 13991-13991  I  app_startup Device boot completed. Starting app.
08:03:46.694 13991-14014  I  received app_startup ApplicationStartInfo: android.app.ApplicationStartInfo@7c736ac4
08:03:46.696 13991-14014  I  Ignored app_startup intent : Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10000000 cmp=com.tomas.repcik.appstartinfodemo/.MainActivity }
08:03:46.696 13991-14014  I  Assembled app_startup bean: AppStartInfoBean(startType=START_TYPE_COLD, startupState=STARTUP_STATE_FIRST_FRAME_DRAWN, startReason=START_REASON_LAUNCHER, launchMode=LAUNCH_MODE_STANDARD, timestamps=StartupTimestamps(applicationOnCreate=90643519153095, bindApplication=90643253397804, firstFrame=90643635532970, fork=90643206380012, fullyDrawn=null, initialRenderThreadFrame=null, launch=90643193354887, postOnCreate=null, preOnCreate=null, reservedRangeSystem=null, surfaceFlingerCompositionComplete=null), wasForceStopped=true)
```

If we implement it like this, with multiple exiting the app and re-launch the app, it will not trigger new `ApplicationStartInfo` because the `addApplicationStartInfoCompletionListener` is removed automatically. This essentially means that it will ignore the warm/hot launch app scenarios. 